### PR TITLE
Refactor hub service settings

### DIFF
--- a/examples/hub_service/jupyterhub_config.py
+++ b/examples/hub_service/jupyterhub_config.py
@@ -19,6 +19,7 @@ id_scopes = [
     "fhirUser",
 ]
 
+
 # Generic OAuthenticator
 c.JupyterHub.authenticator_class = GenericOAuthenticator
 c.GenericOAuthenticator.oauth_callback_url = "http://localhost:8000/hub/oauth_callback"
@@ -42,15 +43,26 @@ c.GenericOAuthenticator.userdata_from_id_token = True
 # Only one field to derive a name from, and it contains (at least) slashes
 c.GenericOAuthenticator.username_claim = lambda r: r["fhirUser"].replace("/", "_")
 
-
 # Below we set up a service that fetches data from the FHIR server
 # using the same server we used for authentication above
+data_scopes = [
+    "launch",
+    "profile",
+    "patient/*.*",
+]
+scopes_for_service = " ".join(id_scopes + data_scopes)
 c.JupyterHub.services = [
     {
         "name": "fhir",
         "url": "http://127.0.0.1:10101",
         "command": ["flask", "run", "--port=10101"],
-        "environment": {"FLASK_APP": "jupyter_smart_on_fhir/hub_service.py"},
+        "environment": {
+            "FLASK_APP": "jupyter_smart_on_fhir/hub_service.py",
+            "SCOPES": scopes_for_service,
+            "CLIENT_ID": client_id,
+            "SSH_KEY_PATH": "jwtRS256.key",
+            "SSH_KEY_ID": "1",
+        },
     },
 ]
 c.JupyterHub.load_roles = [

--- a/examples/server_extension/config.py
+++ b/examples/server_extension/config.py
@@ -14,7 +14,5 @@ c.SMARTExtensionApp.scopes = [
     "fhirUser",
     "launch",
     "patient/*.*",
-    "additional_scope_1",
-    "additional_scope_2",
 ]
 c.SMARTExtensionApp.client_id = "client_id"

--- a/jupyter_smart_on_fhir/auth.py
+++ b/jupyter_smart_on_fhir/auth.py
@@ -22,12 +22,13 @@ class SMARTConfig:
     @classmethod
     def from_url(cls, iss: str, base_url: str, **kwargs):
         app_config = requests.get(f"{iss}/{cls.broadcast_path}").json()
+        scopes = kwargs.pop("scopes", [])
         return cls(
             base_url=base_url,
             fhir_url=iss,
             token_url=app_config["token_endpoint"],
             auth_url=app_config["authorization_endpoint"],
-            **kwargs,
+            scopes=scopes,
         )
 
     def to_dict(self):

--- a/jupyter_smart_on_fhir/auth.py
+++ b/jupyter_smart_on_fhir/auth.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 import requests
 import secrets
 import jwt
@@ -10,7 +10,8 @@ from pathlib import Path
 
 @dataclass
 class SMARTConfig:
-    """Configuration to connect to a FHIR endpoint with SMART authorization"""
+    """Client-side session-scoped configuration to connect to a FHIR endpoint with SMART authorization"""
+
     base_url: str
     fhir_url: str
     token_url: str
@@ -28,6 +29,9 @@ class SMARTConfig:
             auth_url=app_config["authorization_endpoint"],
             **kwargs,
         )
+
+    def to_dict(self):
+        return asdict(self)
 
 
 def generate_state(next_url=None) -> dict:

--- a/jupyter_smart_on_fhir/auth.py
+++ b/jupyter_smart_on_fhir/auth.py
@@ -18,13 +18,14 @@ class SMARTConfig:
     broadcast_path: str = ".well-known/smart-configuration"
 
     @classmethod
-    def from_url(cls, iss: str, base_url: str):
+    def from_url(cls, iss: str, base_url: str, **kwargs):
         app_config = requests.get(f"{iss}/{cls.broadcast_path}").json()
         return cls(
             base_url=base_url,
             fhir_url=iss,
             token_url=app_config["token_endpoint"],
             auth_url=app_config["authorization_endpoint"],
+            **kwargs,
         )
 
 
@@ -59,7 +60,7 @@ def get_jwks_from_key(key_file: Path, key_id: str = "1") -> str:
 
 def load_keys() -> dict[str, bytes]:
     """Load the private key from environment variables"""
-    key_path = Path(os.environ["SSH_KEY_PATH"], "~/.ssh/id_rsa")
+    key_path = Path(os.environ.get("SSH_KEY_PATH", "~/.ssh/id_rsa"))
     key_id = os.environ.get("SSH_KEY_ID", "1")
     try:
         with open(key_path, "rb") as f:

--- a/jupyter_smart_on_fhir/auth.py
+++ b/jupyter_smart_on_fhir/auth.py
@@ -4,7 +4,6 @@ import secrets
 import jwt
 import json
 import os
-import time
 from pathlib import Path
 
 
@@ -20,7 +19,7 @@ class SMARTConfig:
     broadcast_path: str = ".well-known/smart-configuration"
 
     @classmethod
-    def from_url(cls, iss: str, base_url: str, **kwargs):
+    def from_url(cls, iss: str, base_url: str, **kwargs) -> "SMARTConfig":
         app_config = requests.get(f"{iss}/{cls.broadcast_path}").json()
         scopes = kwargs.pop("scopes", [])
         return cls(

--- a/jupyter_smart_on_fhir/hub_service.py
+++ b/jupyter_smart_on_fhir/hub_service.py
@@ -13,26 +13,49 @@ from jupyterhub.services.auth import HubOAuth
 import requests
 from urllib.parse import urlencode
 import jwt
+import base64
 from jupyter_smart_on_fhir.auth import SMARTConfig, generate_state, validate_keys
+from cryptography.fernet import Fernet, InvalidToken
 
 prefix = os.environ.get("JUPYTERHUB_SERVICE_PREFIX", "/")
 auth = HubOAuth(api_token=os.environ["JUPYTERHUB_API_TOKEN"], cache_max_age=60)
 app = Flask(__name__)
+
 # encryption key for session cookies
-app.secret_key = secrets.token_bytes(32)
+secret_key = base64.urlsafe_b64encode(secrets.token_bytes(32))
+app.config["SECRET_KEY"] = secret_key
+app.config["fernet"] = Fernet(secret_key)
+# settings passed from the Hub
+app.config["client_id"] = os.environ["CLIENT_ID"]
+app.config["keys"] = validate_keys()
+
+
+def get_encrypted_cookie(key: str) -> str | None:
+    """Fetch and decrypt an encrypted cookie"""
+    cookie = session.get(key)
+    if cookie:
+        try:
+            return app.config["fernet"].decrypt(cookie).decode("ascii")
+        except InvalidToken:
+            pass  # maybe warn
+    return None
+
+
+def set_encrypted_cookie(key: str, value: str):
+    """Store an encrypted cookie"""
+    session[key] = app.config["fernet"].encrypt(value.encode("ascii"))
 
 
 def generate_jwt() -> str:
     """Generate a JWT for the SMART asymmetric client authentication"""
-    config = SMARTConfig(**session.get("smart_config"))
     jwt_dict = {
-        "iss": session["client_id"],
-        "sub": "client",
-        "aud": config.token_url,
+        "iss": app.config["client_id"],
+        "sub": app.config["client_id"],
+        "aud": session["smart_config"]["token_url"],
         "jti": "jwt_id",
         "exp": int(time.time() + 3600),
     }
-    ((key_id, private_key_path),) = session["keys"].items()
+    ((key_id, private_key_path),) = app.config["keys"].items()
     with open(private_key_path, "rb") as f:
         private_key = f.read()
     headers = {"kid": key_id}
@@ -41,18 +64,24 @@ def generate_jwt() -> str:
 
 def token_for_code(code: str):
     """Exchange an authorization code for an access token"""
-    config = session.get("smart_config")
     data = dict(
-        client_id=session["client_id"],
+        client_id=app.config["client_id"],
         grant_type="authorization_code",
         code=code,
-        redirect_uri=config.base_url + "oauth_callback",
+        redirect_uri=session["smart_config"]["base_url"] + "oauth_callback",
         client_assertion_type="urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         client_assertion=generate_jwt(),
     )
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    token_reply = requests.post(config.token_url, data=data, headers=headers)
-    return token_reply.json()["access_token"]
+    token_reply = requests.post(
+        session["smart_config"]["token_url"], data=data, headers=headers
+    )
+    try:
+        return token_reply.json()["access_token"]
+    except KeyError:
+        raise ValueError(
+            f"No access token in token reply: received error messsage {token_reply.get('error_description')}"
+        )
 
 
 def authenticated(f):
@@ -60,43 +89,40 @@ def authenticated(f):
 
     @wraps(f)
     def decorated(*args, **kwargs):
-        session["client_id"] = os.environ["CLIENT_ID"]
-        session["keys"] = validate_keys()
-        session["smart_config"] = SMARTConfig.from_url(
-            request.args.get("iss"),
-            request.base_url,
-            scopes=os.environ.get("SCOPES", "").split(),
-        )
-        if token := request.cookies.get("smart_token"):
+
+        if token := get_encrypted_cookie("smart_token"):
             return f(token, *args, **kwargs)
 
         else:
+            session["smart_config"] = SMARTConfig.from_url(
+                request.args["iss"],
+                request.base_url,
+                scopes=os.environ.get("SCOPES", "").split(),
+            ).to_dict()
             state = generate_state(next_url=request.path)
-            from_redirect = make_response(start_oauth_flow(state_id=state["state_id"]))
-            from_redirect.set_cookie(secure=True, httponly=True, **state)
-            from_redirect.set_cookie("next_url", state["next_url"])
-            return from_redirect
+            for key in ("next_url", "state_id"):
+                set_encrypted_cookie(key, state[key])
+            return make_response(start_oauth_flow(state_id=state["state_id"]))
 
     return decorated
 
 
 def start_oauth_flow(state_id: str, scopes: list[str] | None = None):
     """Start the OAuth flow by redirecting to the authorization endpoint"""
-    config = session.get("smart_config")
+    config = SMARTConfig(**session.get("smart_config"))
     redirect_uri = config.base_url + "oauth_callback"
     scopes = scopes or config.scopes
     headers = {
         "aud": config.fhir_url,
         "state": state_id,
         "redirect_uri": redirect_uri,
-        "launch": request.args.get("launch"),
-        "client_id": session["client_id"],
+        "launch": request.args["launch"],
+        "client_id": app.config["client_id"],
         "response_type": "code",
         "scopes": " ".join(scopes),
     }
     auth_url = f"{config.auth_url}?{urlencode(headers)}"
-    response = redirect(auth_url)
-    return response
+    return redirect(auth_url)
 
 
 @app.route(prefix)
@@ -108,7 +134,7 @@ def fetch_data(token: str):
         "Accept": "application/fhir+json",
         "User-Agent": "JupyterHub",
     }
-    url = f"{session['smart_config'].fhir_url}/Condition"  # Endpoint with data
+    url = f"{session['smart_config']['fhir_url']}/Condition"  # Endpoint with data
     f = requests.get(url, headers=headers)
     return Response(f.text, mimetype="application/json")
 
@@ -116,8 +142,10 @@ def fetch_data(token: str):
 @app.route(prefix + "oauth_callback")
 def callback():
     """Callback endpoint to finish OAuth flow"""
-    state_id = request.cookies.get("state_id")
-    next_url = request.cookies.get("next_url")
+    state_id = get_encrypted_cookie("state_id")
+    if not state_id:
+        return Response("No local state ID cookie found", status=400)
+    next_url = get_encrypted_cookie("next_url") or "/"
 
     if error := request.args.get("error", False):
         return Response(
@@ -131,6 +159,5 @@ def callback():
     if arg_state != state_id:
         return Response("OAuth state does not match. Try logging in again.", status=403)
     token = token_for_code(code)
-    to_next_url = make_response(redirect(next_url))
-    to_next_url.set_cookie("smart_token", token, secure=True, httponly=True)
-    return to_next_url
+    set_encrypted_cookie("smart_token", token)
+    return make_response(redirect(next_url))

--- a/jupyter_smart_on_fhir/hub_service.py
+++ b/jupyter_smart_on_fhir/hub_service.py
@@ -23,7 +23,6 @@ app = Flask(__name__)
 
 # encryption key for session cookies
 secret_key = base64.urlsafe_b64encode(secrets.token_bytes(32))
-app.config["SECRET_KEY"] = secret_key
 app.config["fernet"] = Fernet(secret_key)
 # settings passed from the Hub
 app.config["client_id"] = os.environ["CLIENT_ID"]
@@ -62,7 +61,7 @@ def generate_jwt() -> str:
     return jwt.encode(jwt_dict, private_key, "RS256", headers)
 
 
-def token_for_code(code: str):
+def token_for_code(code: str) -> str:
     """Exchange an authorization code for an access token"""
     data = dict(
         client_id=app.config["client_id"],
@@ -107,7 +106,7 @@ def authenticated(f):
     return decorated
 
 
-def start_oauth_flow(state_id: str, scopes: list[str] | None = None):
+def start_oauth_flow(state_id: str, scopes: list[str] | None = None) -> Response:
     """Start the OAuth flow by redirecting to the authorization endpoint"""
     config = SMARTConfig(**session.get("smart_config"))
     redirect_uri = config.base_url + "oauth_callback"
@@ -127,7 +126,7 @@ def start_oauth_flow(state_id: str, scopes: list[str] | None = None):
 
 @app.route(prefix)
 @authenticated
-def fetch_data(token: str):
+def fetch_data(token: str) -> Response:
     """Fetch data from a FHIR endpoint"""
     headers = {
         "Authorization": f"Bearer {token}",
@@ -140,7 +139,7 @@ def fetch_data(token: str):
 
 
 @app.route(prefix + "oauth_callback")
-def callback():
+def callback() -> Response:
     """Callback endpoint to finish OAuth flow"""
     state_id = get_encrypted_cookie("state_id")
     if not state_id:

--- a/jupyter_smart_on_fhir/server_extension.py
+++ b/jupyter_smart_on_fhir/server_extension.py
@@ -66,7 +66,7 @@ class SMARTAuthHandler(JupyterHandler):
             self.write(f"Authorization success: Fetched {str(data)}")
             self.finish()
 
-    def get_data(self, token: str):
+    def get_data(self, token: str) -> dict:
         headers = {
             "Authorization": f"Bearer {token}",
             "Accept": "application/fhir+json",
@@ -113,7 +113,7 @@ class SMARTLoginHandler(JupyterHandler):
 class SMARTCallbackHandler(JupyterHandler):
     """Callback handler for SMART on FHIR"""
 
-    def token_for_code(self, code: str):
+    def token_for_code(self, code: str) -> str:
         data = dict(
             client_id=self.settings["client_id"],
             grant_type="authorization_code",

--- a/jupyter_smart_on_fhir/server_extension.py
+++ b/jupyter_smart_on_fhir/server_extension.py
@@ -22,6 +22,7 @@ def _jupyter_server_extension_points():
 
 class SMARTExtensionApp(ExtensionApp):
     """Jupyter server extension for SMART on FHIR"""
+
     name = "fhir"
     scopes = List(
         Unicode(),
@@ -49,6 +50,7 @@ class SMARTExtensionApp(ExtensionApp):
 
 class SMARTAuthHandler(JupyterHandler):
     """Handler for SMART on FHIR authentication"""
+
     @tornado.web.authenticated
     def get(self):
         fhir_url = self.get_argument("iss")
@@ -82,10 +84,11 @@ class SMARTAuthHandler(JupyterHandler):
 
 class SMARTLoginHandler(JupyterHandler):
     """Login handler for SMART on FHIR"""
+
     @tornado.web.authenticated
     def get(self):
         state = generate_state()
-        self.set_secure_cookie("state_id", state["id"])
+        self.set_secure_cookie(**state)
         scopes = self.settings["scopes"]
         smart_config = self.settings["smart_config"]
         auth_url = smart_config.auth_url
@@ -109,6 +112,7 @@ class SMARTLoginHandler(JupyterHandler):
 
 class SMARTCallbackHandler(JupyterHandler):
     """Callback handler for SMART on FHIR"""
+
     def token_for_code(self, code: str):
         data = dict(
             client_id=self.settings["client_id"],

--- a/jupyter_smart_on_fhir/server_extension.py
+++ b/jupyter_smart_on_fhir/server_extension.py
@@ -21,8 +21,8 @@ def _jupyter_server_extension_points():
 
 
 class SMARTExtensionApp(ExtensionApp):
+    """Jupyter server extension for SMART on FHIR"""
     name = "fhir"
-
     scopes = List(
         Unicode(),
         help="""Scopes to request authorization for at the FHIR endpoint""",
@@ -48,6 +48,7 @@ class SMARTExtensionApp(ExtensionApp):
 
 
 class SMARTAuthHandler(JupyterHandler):
+    """Handler for SMART on FHIR authentication"""
     @tornado.web.authenticated
     def get(self):
         fhir_url = self.get_argument("iss")
@@ -80,6 +81,7 @@ class SMARTAuthHandler(JupyterHandler):
 
 
 class SMARTLoginHandler(JupyterHandler):
+    """Login handler for SMART on FHIR"""
     @tornado.web.authenticated
     def get(self):
         state = generate_state()
@@ -106,6 +108,7 @@ class SMARTLoginHandler(JupyterHandler):
 
 
 class SMARTCallbackHandler(JupyterHandler):
+    """Callback handler for SMART on FHIR"""
     def token_for_code(self, code: str):
         data = dict(
             client_id=self.settings["client_id"],


### PR DESCRIPTION
- Split settings in serverside settings and client side settings. 
- Use encrypted cookies for hub service. 

I didn't use any encrypted cookies for the server extension because it's all client-side and doesn't have any persistent secrets, but let me know if I overlooked something.

If this is finished, then I'll move on to unit tests