### PR TITLE
Sandbox testing in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Smart on FHIR in JH tests
+name: JupyterHealth SMART on FHIR test suite
 
 on:
   push:
@@ -12,10 +12,6 @@ jobs:
       matrix:
         python-version: [3.12] # extend if needed
 
-    env:
-      JUPYTERHUB_API_TOKEN: "API_TOKEN"
-      CLIENT_ID: "CLIENT_ID"
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,6 +23,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[testing]
+    - name: Pull Docker image
+    - run: docker pull smartonfhir/smart-launcher-2:latest
+    - name: Run docker container 
+    - run: docker run -d -p 8080:80 --name smart-launcher smartonfhir/smart-launcher-2:latest
+    - name: Wait until ready
+    - run: |
+      until curl -s http://localhost:8080 > /dev/null; do
+        echo "Waiting for container startup"
+        sleep 5
+      done
     - name: Run tests
       run: |
         pytest tests/
+
+    

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
       run: | 
         git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
         cd smart-launcher-v2
-        npm ci --omit=dev
+        npm ci
         npm run build
       env: 
         PORT: 5555

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '18.x'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -32,7 +32,6 @@ jobs:
         git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
         cd smart-launcher-v2
         npm install
-        npm run build
       env: 
         NODE_ENV: production
         PORT: 5555

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,10 +23,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[testing]
-    - name: Download SMART sandbox
-      run: git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
-    - name: Build sandbox
-      run: |
+    - name: Build SMART sandbox
+      run: | 
+        git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
+        cd smart-launcher-v2
+        npm install -g
         npm run build
       env: 
         NODE_ENV: production
@@ -34,5 +35,7 @@ jobs:
     - name: Run tests
       run: |
         pytest tests/
+      env: 
+        SANDBOX_DIR: ${{ github.workspace }}/smart-launcher-v2
 
     

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -27,7 +31,7 @@ jobs:
       run: | 
         git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
         cd smart-launcher-v2
-        npm install -g
+        npm install
         npm run build
       env: 
         NODE_ENV: production

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,13 +27,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[testing]
-    - name: Build SMART sandbox
+    - name: Install SMART sandbox
       run: | 
         git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
         cd smart-launcher-v2
-        npm install
+        npm ci --omit=dev
+        npm run build
       env: 
-        NODE_ENV: production
         PORT: 5555
     - name: Run tests
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Run demo tests
+name: Smart on FHIR in JH tests
 
 on:
   push:
@@ -11,6 +11,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.12] # extend if needed
+
+    env:
+      JUPYTERHUB_API_TOKEN: "API_TOKEN"
+      CLIENT_ID: "CLIENT_ID"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,10 +29,10 @@ jobs:
     - run: docker run -d -p 8080:80 --name smart-launcher smartonfhir/smart-launcher-2:latest
     - name: Wait until ready
     - run: |
-      until curl -s http://localhost:8080 > /dev/null; do
-        echo "Waiting for container startup"
-        sleep 5
-      done
+        until curl -s http://localhost:8080 > /dev/null; do
+          echo "Waiting for container startup"
+          sleep 5
+        done
     - name: Run tests
       run: |
         pytest tests/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,6 +31,7 @@ jobs:
       run: | 
         git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
         cd smart-launcher-v2
+        git switch -c aa0f3b1 # Fix the version we use for the sandbox
         npm ci
         npm run build
       env: 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,11 +24,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[testing]
     - name: Pull Docker image
-    - run: docker pull smartonfhir/smart-launcher-2:latest
+      run: docker pull smartonfhir/smart-launcher-2:latest
     - name: Run docker container 
-    - run: docker run -d -p 8080:80 --name smart-launcher smartonfhir/smart-launcher-2:latest
+      run: docker run -d -p 8080:80 --name smart-launcher smartonfhir/smart-launcher-2:latest
     - name: Wait until ready
-    - run: |
+      run: |
         until curl -s http://localhost:8080 > /dev/null; do
           echo "Waiting for container startup"
           sleep 5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,16 +23,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[testing]
-    - name: Pull Docker image
-      run: docker pull smartonfhir/smart-launcher-2:latest
-    - name: Run docker container 
-      run: docker run -d -p 8080:80 --name smart-launcher smartonfhir/smart-launcher-2:latest
-    - name: Wait until ready
+    - name: Download SMART sandbox
+      run: git clone https://github.com/smart-on-fhir/smart-launcher-v2.git
+    - name: Build sandbox
       run: |
-        until curl -s http://localhost:8080 > /dev/null; do
-          echo "Waiting for container startup"
-          sleep 5
-        done
+        npm run build
+      env: 
+        NODE_ENV: production
+        PORT: 5555
     - name: Run tests
       run: |
         pytest tests/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,28 @@
+name: Run demo tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12] # extend if needed
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: "pip"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[testing]
+    - name: Run tests
+      run: |
+        pytest tests/

--- a/jupyter_smart_on_fhir/auth.py
+++ b/jupyter_smart_on_fhir/auth.py
@@ -60,7 +60,7 @@ def get_jwks_from_key(key_file: Path, key_id: str = "1") -> str:
     jwk = alg.to_jwk(key, as_dict=True)
     jwk.update({"alg": "RS256", "kid": key_id})
     jwks_smart = {"keys": [jwk]}
-    jwks_smart_str = json.dumps(jwks_smart, indent=2)
+    jwks_smart_str = json.dumps(jwks_smart)
     return jwks_smart_str
 
 

--- a/jupyter_smart_on_fhir/hub_service.py
+++ b/jupyter_smart_on_fhir/hub_service.py
@@ -16,7 +16,6 @@ from flask import (
     request,
     session,
     current_app,
-    abort,
 )
 import requests
 from urllib.parse import urlencode
@@ -140,9 +139,9 @@ def authenticated(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         if "iss" not in request.args:
-            abort(
-                400,
-                "GET request does not have iss parameter. Was service launched from EHR?",
+            return Response(
+                "GET request misses 'iss' argument. Was service launched from EHR?",
+                status=400,
             )
 
         if token := get_encrypted_cookie("smart_token"):

--- a/jupyter_smart_on_fhir/hub_service.py
+++ b/jupyter_smart_on_fhir/hub_service.py
@@ -66,7 +66,9 @@ def create_app():
             )
         code = request.args.get("code")
         if not code:
-            return Response("OAuth callback made without a token", status=400)
+            return Response(
+                "OAuth callback did not return authorization code", status=400
+            )
         arg_state = request.args.get("state", None)
         if arg_state != state_id:
             return Response(
@@ -152,7 +154,6 @@ def authenticated(f):
                 request.base_url,
                 scopes=os.environ.get("SCOPES", "").split(),
             ).to_dict()
-
             state = generate_state(next_url=request.path)
             for key in ("next_url", "state_id"):
                 set_encrypted_cookie(key, state[key])

--- a/jupyter_smart_on_fhir/server_extension.py
+++ b/jupyter_smart_on_fhir/server_extension.py
@@ -31,7 +31,7 @@ class SMARTExtensionApp(ExtensionApp):
     ).tag(config=True)
 
     client_id = Unicode(
-        help="""Client ID for the SMART application""", default_value="test-id"
+        help="""Client ID for the SMART application""", default_value="test_id"
     ).tag(config=True)
 
     def initialize_settings(self):
@@ -88,7 +88,10 @@ class SMARTLoginHandler(JupyterHandler):
     @tornado.web.authenticated
     def get(self):
         state = generate_state()
-        self.set_secure_cookie(**state)
+        self.set_secure_cookie("state_id", state["state_id"])
+        if state["next_url"]:
+            self.set_secure_cookie("next_url", state["next_url"])
+
         scopes = self.settings["scopes"]
         smart_config = self.settings["smart_config"]
         auth_url = smart_config.auth_url
@@ -98,7 +101,7 @@ class SMARTLoginHandler(JupyterHandler):
         code_challenge = base64.urlsafe_b64encode(code_challenge_b).rstrip(b"=")
         headers = {
             "aud": smart_config.fhir_url,
-            "state": state["id"],
+            "state": state["state_id"],
             "launch": self.settings["launch"],
             "redirect_uri": urljoin(self.request.full_url(), callback_path),
             "client_id": self.settings["client_id"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,10 @@ import os
 import subprocess
 import requests
 import time
+from dataclasses import asdict, field, dataclass
+import base64
+import json
+from urllib import parse
 
 
 @pytest.fixture(scope="function")  # module?
@@ -27,3 +31,64 @@ def sandbox():
         raise requests.ConnectionError(f"Cannot connect to {url}")
     yield url
     a.kill()
+
+
+@dataclass
+class SandboxConfig:
+    """Taken from smart-on-fhir/smart-launcher-v2.git:src/isomorphic/LaunchOptions.ts.
+    The sandbox reads its configuration from the url it's launched with.
+    This means we don't have to introduce a webdriver to manipulate it's behaviour,
+    but instead we can reverse engineer the parameters to set the necessary parameters
+    """
+
+    # Caveat: make sure not to change the order
+    # the smart sandbox uses list indices to evaluate which value is which property
+    # Assumes client identity validation = true
+    launch_type: int = 0  # provider EHR launch
+    patient_ids: list[str] = field(default_factory=list)
+    provider_ids: list[str] = field(default_factory=list)
+    encounter_type: str = "AUTO"
+    misc_skip_login: int = 0  # not compatible with provider EHR launch
+    misc_skip_auth: int = 0  # not compatible with provider EHR launch
+    misc_simulate_launch: int = 0  # don't simulate launch within EHR UI
+    allowed_scopes: set[str] = field(default_factory=set)
+    redirect_uris: list[str] = field(default_factory=list)
+    client_id: str = "client_id"
+    client_secret: str = ""
+    auth_error: int = 0  # simulate no error
+    jwks_url: str = ""
+    jwks: str = ""
+    client_type: int = 0  # 0 (public), 1 (symmetric), 2 (asymmetric)
+    pkce_validation: int = 1  # 0 (none), 1 (auto), 2 (always)
+    fhir_base_url: str = ""  # arranged server side
+
+    def get_launch_code(self) -> str:
+        """The sandbox settings are encoded in a base64 JSON object.
+        Enforcing settings/procedures needs to be done here
+        """
+
+        attr_list = []
+        for val in asdict(self).values():
+            if isinstance(val, int) or isinstance(val, str):
+                attr_list.append(val)
+            elif isinstance(val, list):
+                attr_list.append(", ".join(val))
+            elif isinstance(val, set):
+                attr_list.append(" ".join(val))
+        attr_repr = json.dumps(attr_list)
+        return base64.b64encode(attr_repr.encode("utf-8"))
+
+    def get_url_query(
+        self, launch_url: str, validation: bool = True, fhir_version: str = "r4"
+    ) -> str:
+        """Provide the entire URL query that loads the sandbox with the given settings.
+        Requires appending with base url"""
+        query = parse.urlencode(
+            {
+                "launch": self.get_launch_code(),
+                "launch_url": launch_url,
+                "validation": int(validation),
+                "fhir_version": fhir_version,
+            }
+        )
+        return query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,7 @@ def sandbox():
     port = 5555
     os.environ["PORT"] = str(port)
     a = subprocess.Popen(
-        ["npm", "run", "start:prod"],
-        cwd=os.environ.get("SANDBOX_DIR", ".")
+        ["npm", "run", "start:prod"], cwd=os.environ.get("SANDBOX_DIR", ".")
     )
     url = f"http://localhost:{port}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def sandbox():
         except requests.ConnectionError:
             pass
         time.sleep(1)  # Wait for 1 second before retrying
-
+    else:
+        raise requests.ConnectionError(f"Cannot connect to {url}")
     yield url
     a.kill()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+import os
+import subprocess
+import requests
+import time
+
+
+@pytest.fixture(scope="function")  # module?
+def sandbox():
+    port = 5555
+    os.environ["PORT"] = str(port)
+    a = subprocess.Popen(
+        ["npm", "run", "start:prod"],
+        cwd=os.environ.get("SANDBOX_DIR", ".")
+    )
+    url = f"http://localhost:{port}"
+
+    # Wait until the frontend is ready
+    for _ in range(10):
+        try:
+            response = requests.get(url)
+            if response.status_code == 200:
+                break
+        except requests.ConnectionError:
+            pass
+        time.sleep(1)  # Wait for 1 second before retrying
+
+    yield url
+    a.kill()

--- a/tests/test_hub_service.py
+++ b/tests/test_hub_service.py
@@ -1,10 +1,65 @@
 import pytest
 from flask import session
 from jupyter_smart_on_fhir.hub_service import (
-    app,
+    create_app,
     set_encrypted_cookie,
     get_encrypted_cookie,
 )
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import os
+
+
+@pytest.fixture(scope="module")
+def keys(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("keys")
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    key_name = "jwtRS256.key"
+    private_key_path = tmp_path / key_name
+    public_key_path = tmp_path / f"{key_name}.pub"
+    private_key_path.write_bytes(private_pem)
+    public_key_path.write_bytes(public_pem)
+    return {"SSH_KEY_PATH": str(private_key_path), "SSH_KEY_ID": "test_key"}
+
+
+@pytest.fixture(scope="function")
+def mock_env(monkeypatch, keys):
+    env = {
+        "JUPYTERHUB_API_TOKEN": os.getenv("JUPYTERHUB_API_TOKEN", "API_TOKEN"),
+        "CLIENT_ID": os.getenv("CLIENT_ID", "CLIENT_ID"),
+        "SCOPES": os.getenv("SCOPES", "launch profile patient/*.*"),
+    } | keys
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return env
+
+
+@pytest.fixture(scope="function")
+def test_app(mock_env):
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture(scope="function")
+def client(test_app):
+    return test_app.test_client()
+
+
+def test_ehr_launch(client):
+    response = client.get("/?token=hello")
+    assert response.status_code == 400
 
 
 @pytest.mark.parametrize(
@@ -17,8 +72,8 @@ from jupyter_smart_on_fhir.hub_service import (
         ("special_chars", "!@#$%^&*()_+"),
     ],
 )
-def test_encrypted_cookie(key, value):
-    with app.test_request_context():
+def test_encrypted_cookie(test_app, key, value):
+    with test_app.test_request_context():
         session.clear()
         # Set the encrypted cookie
         set_encrypted_cookie(key, value)
@@ -31,15 +86,15 @@ def test_encrypted_cookie(key, value):
         assert decrypted_value == value
 
 
-def test_get_nonexistent_cookie():
-    with app.test_request_context():
+def test_get_nonexistent_cookie(test_app):
+    with test_app.test_request_context():
         session.clear()
         value = get_encrypted_cookie("nonexistent_key")
         assert value is None
 
 
-def test_invalid_token():
-    with app.test_request_context():
+def test_invalid_token(test_app):
+    with test_app.test_request_context():
         session.clear()
         session["invalid_key"] = b"invalid_token"
         value = get_encrypted_cookie("invalid_key")

--- a/tests/test_hub_service.py
+++ b/tests/test_hub_service.py
@@ -1,0 +1,46 @@
+import pytest
+from flask import session
+from jupyter_smart_on_fhir.hub_service import (
+    app,
+    set_encrypted_cookie,
+    get_encrypted_cookie,
+)
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("test_key", "test_value"),
+        ("user_id", "12345"),
+        ("session_token", "abcdef123456"),
+        ("empty_value", ""),
+        ("special_chars", "!@#$%^&*()_+"),
+    ],
+)
+def test_encrypted_cookie(key, value):
+    with app.test_request_context():
+        session.clear()
+        # Set the encrypted cookie
+        set_encrypted_cookie(key, value)
+        # Verify the cookie is in the session and encrypted
+        assert key in session
+        assert session[key] != value
+        # Get the decrypted cookie value
+        decrypted_value = get_encrypted_cookie(key)
+        # Verify the decrypted value matches the original
+        assert decrypted_value == value
+
+
+def test_get_nonexistent_cookie():
+    with app.test_request_context():
+        session.clear()
+        value = get_encrypted_cookie("nonexistent_key")
+        assert value is None
+
+
+def test_invalid_token():
+    with app.test_request_context():
+        session.clear()
+        session["invalid_key"] = b"invalid_token"
+        value = get_encrypted_cookie("invalid_key")
+        assert value is None

--- a/tests/test_hub_service.py
+++ b/tests/test_hub_service.py
@@ -157,4 +157,4 @@ def test_to_auth_url(sandbox, client, asymmetric_auth):
         #     }
         #     token = token_for_code(code)
         #     assert isinstance(token, str)
-        # FIXME: The session seems to be empty, but only for this method. Don't understand why
+        # FIXME: The session seems to be empty, but only for the token_for_code method. Confusing

--- a/tests/test_hub_service.py
+++ b/tests/test_hub_service.py
@@ -8,6 +8,7 @@ from jupyter_smart_on_fhir.hub_service import (
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 import os
+import requests
 
 
 @pytest.fixture(scope="module")
@@ -99,3 +100,9 @@ def test_invalid_token(test_app):
         session["invalid_key"] = b"invalid_token"
         value = get_encrypted_cookie("invalid_key")
         assert value is None
+
+
+def test_access_sandbox(sandbox):
+    f = requests.get(sandbox)
+    print(f.status_code, f.text)
+    assert f.status_code == 200

--- a/tests/test_server_extension.py
+++ b/tests/test_server_extension.py
@@ -1,0 +1,98 @@
+import os
+import subprocess
+from urllib.parse import urlencode, unquote
+import requests
+import pytest
+from conftest import wait_for_server, SandboxConfig
+from jupyter_smart_on_fhir.server_extension import smart_path, login_path, callback_path
+
+PORT = os.getenv("TEST_PORT", 18888)
+ext_url = f"http://localhost:{PORT}"
+
+
+def request_api(url, session=None, params=None, **kwargs):
+    query_args = {"token": "secret"}
+    query_args.update(params or {})
+    session = session or requests.Session()
+    return session.get(url, params=query_args, **kwargs)
+
+
+@pytest.fixture
+def jupyterdir(tmpdir):
+    path = tmpdir.join("jupyter")
+    path.mkdir()
+    return str(path)
+
+
+@pytest.fixture
+def jupyter_server(tmpdir, jupyterdir):
+    client_id = os.environ["CLIENT_ID"] = "client_id"
+    env = os.environ.copy()
+    # avoid interacting with user configuration, state
+    env["JUPYTER_CONFIG_DIR"] = str(tmpdir / "dotjupyter")
+    env["JUPYTER_RUNTIME_DIR"] = str(tmpdir / "runjupyter")
+
+    extension_command = ["jupyter", "server", "extension"]
+    command = [
+        "jupyter-server",
+        "--ServerApp.token=secret",
+        "--SMARTExtensionApp.client_id={}".format(client_id),
+        "--port={}".format(PORT),
+    ]
+    subprocess.check_call(
+        extension_command + ["enable", "jupyter_smart_on_fhir.server_extension"],
+        env=env,
+    )
+
+    # launch the server
+    with subprocess.Popen(command, cwd=jupyterdir, env=env) as jupyter_proc:
+        wait_for_server(ext_url)
+        yield jupyter_proc
+        jupyter_proc.terminate()
+
+
+def test_uninformed_endpoint(jupyter_server):
+    response = request_api(ext_url + smart_path)
+    assert response.status_code == 400
+
+
+@pytest.fixture(scope="function")
+def public_client():
+    return SandboxConfig(
+        client_id=os.environ["CLIENT_ID"],
+        client_type=0,
+        pkce_validation=2,
+        # setting IDs so we omit login screen in sandbox; unsure I would test that flow
+        patient_ids=["6bb97c2b-8762-4763-ad16-2d88db590b74"],
+        provider_ids=["63003abb-3924-46df-a75a-0a1f42733189"],
+    )
+
+
+def test_login_handler(jupyter_server, sandbox, public_client):
+    session = requests.Session()
+    # Try endpoint and get redirected to login
+    query = {"iss": f"{sandbox}/v/r4/fhir", "launch": public_client.get_launch_code()}
+    response = request_api(
+        ext_url + smart_path, params=query, allow_redirects=False, session=session
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"] == login_path
+
+    # Login with headers and get redirected to auth url
+    response = request_api(ext_url + login_path, session=session, allow_redirects=False)
+    assert response.status_code == 302
+    auth_url = response.headers["Location"]
+    assert auth_url.startswith(sandbox)
+
+    # Internally, get redirected to provider-auth
+    response = request_api(auth_url, session=session, allow_redirects=False)
+    assert response.status_code == 302
+    auth_url = response.headers["Location"]
+    callback_url = response.headers["Location"]
+    assert callback_url.startswith(ext_url + callback_path)
+    assert "code=" in callback_url
+    response = request_api(callback_url, session=session)
+    assert response.status_code == 200
+    assert response.url.startswith(ext_url + smart_path)
+
+    # TODO: Should I test token existence? And how?

--- a/tests/test_server_extension.py
+++ b/tests/test_server_extension.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from urllib.parse import urlencode, unquote
 import requests
 import pytest
 from conftest import wait_for_server, SandboxConfig
@@ -69,6 +68,7 @@ def public_client():
 
 
 def test_login_handler(jupyter_server, sandbox, public_client):
+    """I think this test can be splitted in three with some engineering. Perhaps useful, not sure"""
     session = requests.Session()
     # Try endpoint and get redirected to login
     query = {"iss": f"{sandbox}/v/r4/fhir", "launch": public_client.get_launch_code()}
@@ -87,7 +87,6 @@ def test_login_handler(jupyter_server, sandbox, public_client):
     # Internally, get redirected to provider-auth
     response = request_api(auth_url, session=session, allow_redirects=False)
     assert response.status_code == 302
-    auth_url = response.headers["Location"]
     callback_url = response.headers["Location"]
     assert callback_url.startswith(ext_url + callback_path)
     assert "code=" in callback_url


### PR DESCRIPTION
Set up unit testing and integration testing with CI.
# Backend changes
- Changes app setup from 'on import' to 'with factory', to make testing easier

# Testing setup
- Add CI in Github Actions to install package and run unit tests
- Add cloning and installing SMART sandbox in Github Actions
- Add fixtures for 
  - Hub service app
  - RSA key generation
  - Sandbox setup
  - Sandbox configuration
- Add unit tests for hub service

# Notes
- I had to reverse engineer the sandbox a bit to find out how they set up their launch url. 
- I did not succeed in testing the token for code exchange, something is off with the flask test session management 
